### PR TITLE
feat!: read shmuxfiles from parent folders and support shebang in scripts

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,14 @@
+name: Test
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+      - run: go test ./...

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .build
 .DS_Store
+shmux-dev

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .build
-shmux.*
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Head to the [releases](https://github.com/shikaan/shmux/releases) page and downl
 
 ### Usage
 
-A common use case for `shmux` is running simple scripts for your app in a standardised and language agnostic way. These scripts are to be found in the _configuraiton_ file, also known as _shmuxfile_.
+A common use case for `shmux` is running simple scripts in a standardized and language-agnostic way. These scripts are to be found in the _configuration_ file, also known as _shmuxfile_.
 
-For exmaple, a `shmux.sh` for a Go project might look like: 
+For example, a `shmuxfile.sh` for a Go project might look like: 
 
 ```sh
 build:
@@ -41,7 +41,7 @@ greet:
   echo "Hello $1, my old friend"
 ```
 
-Which can then be utilized from within the same folder as
+Which can then be utilized as
 
 ```bash
 # Runs the test command
@@ -57,7 +57,7 @@ $ shmux greet -- "darkness"
 
 ### More Usage
 
-What if we wanted to write the scripts in JavaScript? Well, you then just need a `shmux.js` which reads something like
+What if we wanted to write the scripts in JavaScript? Well, you then just need a `shmuxfile.js` which reads something like
 
 ```js
 greet:
@@ -74,11 +74,10 @@ and run it like
 
 ```bash
 # As flags
-$ shmux -config="shmux.js" -shell=$(which node) greet -- "Manuel"
+$ shmux -shell=$(which node) greet -- "Manuel"
 # => Hello Manuel, from greet
 
 # or from environment
-export SHMUX_CONFIG="shmux.js"
 export SHMUX_SHELL=$(which node)
 
 shmux greet -- "Manuel"
@@ -98,7 +97,7 @@ More detailed documentation can be found [here](./docs/docs.md).
 
   As long as the language you choose is fine with having strings like `script:` in its syntax, you can just piggy-back on the existing editor support. 
   
-  For example, if your _shmuxfile_ hosts JavaScript code, calling it `shmux.js` will give you decent syntax highlighting out of the box in most editors.
+  For example, if your _shmuxfile_ hosts JavaScript code, calling it `shmuxfile.js` will give you decent syntax highlighting out of the box in most editors.
 
   More sophisticated editor support may be coming soon. If you are interested, feel free to open an issue.
 

--- a/README.md
+++ b/README.md
@@ -57,10 +57,12 @@ $ shmux greet -- "darkness"
 
 ### More Usage
 
-What if we wanted to write the scripts in JavaScript? Well, you then just need a `shmuxfile.js` which reads something like
+What if we wanted to write the scripts in JavaScript? Well, you then just need a `shmuxfile.js` with a [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) defining the interpreter to be used and you're set.
 
 ```js
 greet:
+  #!/usr/bin/env node
+
   const friend = "$1"
   const author = "$@"
   const message = friend === "darkness" 
@@ -73,14 +75,8 @@ greet:
 and run it like
 
 ```bash
-# As flags
-$ shmux -shell=$(which node) greet -- "Manuel"
+$ shmux greet -- "Manuel"
 # => Hello Manuel, from greet
-
-# or from environment
-export SHMUX_SHELL=$(which node)
-
-shmux greet -- "Manuel"
 ```
 
 ## 📄 Documentation

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -1,13 +1,10 @@
-# shmux: Documentation
+# shmux
 
-<details>
-<summary>Table of contents</summary>
+### Table of contents
 
 * [Configuration](#configuration)
 * [Runtime](#runtime)
 * [Environment, flags, and defaults](#environment-flags-and-defaults)
-
-</details>
 
 ## Configuration
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -38,3 +38,11 @@ In the runtime, scripts have the following variables available
 |---          |--- |
 | `$1`..`$9`  | Respectively the first 9 arguments passed after the `--` separator
 | `$@`        | Holds the name of the current running script
+
+## Environment, flags, and defaults
+
+The general rule is that as little configuration as possible should be provided for `shmux` to run. It is in fact possible to provide no configuration and have `shmux` operating on sensible defaults most of the times. However, `shmux` also provides means to customise its behaviour, namely CLI flags and environment variables. 
+
+Hierarachy for those configuration points goes as follows: CLI flags take precedence over everything, environment variables can be overridden by CLI flags, and lack of both flags and environment variables will make `shmux` operate on defaults.
+
+In short: `CLI flags > Environment Variables > defaults` where the `>` symbol refers to the precedence given to these options.

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -20,17 +20,17 @@ A script is composed of all the lines in between two script definitions or last 
 
 In a nutshell, `shmux` is not opinionated about which languages the script are written in and - so long as the syntax allows[^1] - editor support comes out of the box. Calling the shmuxfile with the most common extension of your language of choice, will make it significantly easier.
 
-For example, a shmuxfile with bash scripts can be called `shmux.bash`. If it was with JavaScript scripts, it can be called `shmux.js`. This will yield pretty decent syntax highlighting.
+For example, a shmuxfile with bash scripts can be called `shmuxfile.bash`. If it was with JavaScript scripts, it can be called `shmuxfile.js`. This will yield pretty decent syntax highlighting.
 
 If you need more sophisticated tooling, please [open an Issue](https://github.com/shikaan/shmux/issues).
 
-[^1]: Namely, permits intendations and presence of `script:`.
+[^1]: Namely, permits intendations and presence of the `script:` labels.
 
 ## Runtime
 
 All the scripts are executed in isolation. Under the hood, `shmux` parses the file, creates a temporary file with it's content and runs it with the specified shell.
 
-This means that all the line in the same script share scope, as if they were on a single file.
+This means that all the lines in the same script share scope, as if they were on a single file.
 
 In the runtime, scripts have the following variables available
 
@@ -45,4 +45,9 @@ The general rule is that as little configuration as possible should be provided 
 
 Hierarachy for those configuration points goes as follows: CLI flags take precedence over everything, environment variables can be overridden by CLI flags, and lack of both flags and environment variables will make `shmux` operate on defaults.
 
-In short: `CLI flags > Environment Variables > defaults` where the `>` symbol refers to the precedence given to these options.
+In short: `CLI flags > Environment Variables > defaults` where the `>` means "takes precedence over".
+
+| CLI Flag          | Environment Variable  | Default       | Description   |
+|---                |---                    |               | --- |
+| `-configuration`  | `SHMUX_CONFIG`        | `shmuxfile.*` | Location of the _shmuxfile_. If not found, 
+| `-shell`          | `SHMUX_SHELL`         | `/bin/sh`     | Holds the name of the current running script

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -5,6 +5,7 @@
 
 * [Configuration](#configuration)
 * [Runtime](#runtime)
+* [Environment, flags, and defaults](#environment-flags-and-defaults)
 
 </details>
 
@@ -34,20 +35,20 @@ This means that all the lines in the same script share scope, as if they were on
 
 In the runtime, scripts have the following variables available
 
-| Variable    | Description   |
-|---          |--- |
-| `$1`..`$9`  | Respectively the first 9 arguments passed after the `--` separator
-| `$@`        | Holds the name of the current running script
+| Variable    | Description                                                         |
+|---          |---                                                                  |
+| `$1`..`$9`  | Respectively the first 9 arguments passed after the `--` separator  |
+| `$@`        | Holds the name of the current running script                        |
 
 ## Environment, flags, and defaults
 
 The general rule is that as little configuration as possible should be provided for `shmux` to run. It is in fact possible to provide no configuration and have `shmux` operating on sensible defaults most of the times. However, `shmux` also provides means to customise its behaviour, namely CLI flags and environment variables. 
 
-Hierarachy for those configuration points goes as follows: CLI flags take precedence over everything, environment variables can be overridden by CLI flags, and lack of both flags and environment variables will make `shmux` operate on defaults.
+Hierarachy for those configuration points goes as follows: inline configuration (when applicable) takes precedence over everything, CLI flags override environment variables, and lack of any of them will make `shmux` operate on defaults.
 
-In short: `CLI flags > Environment Variables > defaults` where the `>` means "takes precedence over".
+In short: `inline configuration > CLI flags > environment variables > defaults` where the `>` means "takes precedence over".
 
-| CLI Flag          | Environment Variable  | Default       | Description   |
-|---                |---                    |               | --- |
-| `-configuration`  | `SHMUX_CONFIG`        | `shmuxfile.*` | Location of the _shmuxfile_. If not found, 
-| `-shell`          | `SHMUX_SHELL`         | `/bin/sh`     | Holds the name of the current running script
+| CLI Flag          | Environment Variable  | Default               | Description                                                 |
+|---                |---                    | ---                   | ---                                                         |
+| `-configuration`  | `SHMUX_CONFIG`        | closest `shmuxfile.*` | Location of the _shmuxfile_.                                |
+| `-shell`          | `SHMUX_SHELL`         | current `$SHELL`      | Interpreter to run the script. Overriden by inline shebang. |

--- a/main.go
+++ b/main.go
@@ -22,10 +22,10 @@ func main() {
 		return
 	}
 
-	script, err := scripts.ReadScript(scriptName, file)
+	script, err := scripts.ReadScript(scriptName, shell, file)
 	exceptions.HandleException(err)
 
-	output, err := scripts.RunScript(script, scriptName, shell, args)
+	output, err := scripts.RunScript(script, args)
 	exceptions.HandleException(err)
 
 	fmt.Print(output)

--- a/pkg/arguments/arguments.go
+++ b/pkg/arguments/arguments.go
@@ -7,11 +7,11 @@ import (
 	"path/filepath"
 )
 
-const CONFIGURATION_GLOB = "shmuxfile.*"
-const CONFIGURATION_ENVIRONMENT = "SHMUX_CONFIG"
-const DEFAULT_SHELL = "/bin/sh"
-const SHELL_ENVIRONMENT = "SHMUX_SHELL"
 const ARGUMENT_SEPARATOR = "--"
+const CONFIGURATION_GLOB = "shmuxfile.*"
+const DEFAULT_SHELL = "/bin/sh"
+const ENVIRONMENT_CONFIGURATION = "SHMUX_CONFIG"
+const ENVIRONMENT_SHELL = "SHMUX_SHELL"
 const HELP_SCRIPT = "$$$$___HELP___$$$$"
 const HELP_TEXT = `usage: shmux [-config <path>] [-shell <path>] <script> -- [arguments ...]
 
@@ -36,9 +36,9 @@ func Parse() (shell string, config string, scriptName string, arguments []string
 
 	flag.Parse()
 
-	shell = oneOf(*shellFlag, os.Getenv(SHELL_ENVIRONMENT), DEFAULT_SHELL)
+	shell = oneOf(*shellFlag, os.Getenv(ENVIRONMENT_SHELL), DEFAULT_SHELL)
 
-	config, err = getConfigurationLocation(oneOf(*configFlag, os.Getenv(CONFIGURATION_ENVIRONMENT)))
+	config, err = getConfigurationLocation(oneOf(*configFlag, os.Getenv(ENVIRONMENT_CONFIGURATION)))
 	if err != nil {
 		return
 	}

--- a/shmuxfile.sh
+++ b/shmuxfile.sh
@@ -1,0 +1,3 @@
+build:
+  go build -o shmux-dev .
+  cp shmux-dev /usr/local/bin/shmux-dev


### PR DESCRIPTION
## Breaking Change

Default _shmuxfile_ is now any `shmuxfile.*` in the current or parent folders. It used to be `shmux.sh`, but the documentation always referenced _shmuxfiles_ and I figured this way it was easier to follow.

## Features

* Configuration can now be read from any parent folder (no mode `cd ..` before running `shmux`)
* Scripts can now declare a `#!` directive which will be honored when running the scripts

## Issues
- Closes #3 
- Closes #1 